### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
 name: Release
+permissions:
+  contents: write
+  packages: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ajiwo/demo-action/security/code-scanning/1](https://github.com/ajiwo/demo-action/security/code-scanning/1)

To fix the problem, add a `permissions` block at the top level of the workflow (just after the `name` field and before `on:`), specifying the least privileges required for the workflow to function. For this workflow, the following permissions are needed:
- `contents: write` (to create a release and upload release assets)
- `packages: write` (to push Docker images to the GitHub Container Registry)

Add the following block near the top of the file:
```yaml
permissions:
  contents: write
  packages: write
```
This ensures the `GITHUB_TOKEN` used by the workflow only has the necessary permissions, reducing the risk of privilege escalation or accidental misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
