### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ajiwo/demo-action/security/code-scanning/2](https://github.com/ajiwo/demo-action/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` key in the workflow to restrict the `GITHUB_TOKEN` to the least privilege required. Since the workflow only checks out code, sets up Go, installs a linter, and runs `make ci`, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
